### PR TITLE
添加了锚点链接的边界，解决侧边栏高亮内容显示有误的问题

### DIFF
--- a/src/components/NWSection/NWSectionComponent.vue
+++ b/src/components/NWSection/NWSectionComponent.vue
@@ -5,7 +5,7 @@
                 {{ title }}
             </div>
             <slot />
-            <n-divider v-if="level == 1" />
+            <n-divider v-if="level == '1'" />
         </div>
     </div>
 
@@ -13,14 +13,21 @@
 </template>
 <script lang="ts" setup>
 import { computed } from 'vue';
+
 const props = defineProps(['title', 'id', 'level']);
+
+interface NWSectionProps{
+    title:string|undefined,
+    id?:string,
+    level:string
+}
 
 const title_classes = computed(() => {
     return {
-        'text-xl': props.level == 1,
+        'text-xl': props.level == '1',
         'font-bold': true,
-        'text-gray-800': props.level == 2,
-        'text-lg': props.level == 2
+        'text-gray-800': props.level == '2',
+        'text-lg': props.level == '2'
     }
 })
 </script>

--- a/src/views/ReadView.vue
+++ b/src/views/ReadView.vue
@@ -121,7 +121,7 @@
       <div class="font-bold m-2">
         当前页面内容
       </div>
-      <n-anchor :ignore-gap="true"  :offset-target="() => contentRef">
+      <n-anchor :bound=100 :ignore-gap="true"  :offset-target="() => contentRef">
         <template v-for="(item, index) in configuration.page_data?.sections" :key="index">
           <n-anchor-link v-if="item.title" :title="(index + 1) + '.' + item.title" :href="'#section' + index" />
         </template>


### PR DESCRIPTION
作者你好，我在这个项目中的组件ReadView.vue组件中为第124行中的n-anchor组件添加了一个“:bound=100”，设置锚点链接的边界为 100 像素，这意味着链接将会在距离目标 100 像素范围内平滑滚动，这样就解决了issue侧边栏高亮内容显示有误。期待回复，谢谢！